### PR TITLE
Typo fix on Data.ts : Whislist to Wishlist

### DIFF
--- a/src/app/components/faq-two.tsx
+++ b/src/app/components/faq-two.tsx
@@ -118,6 +118,7 @@ export default function FaqTwo() {
                           : ""
                       }`}
                     >
+                      
                       <span>{item.title}</span>
                       <FiChevronUp
                         className={`size-4 shrink-0 ${

--- a/src/app/components/lead-form.tsx
+++ b/src/app/components/lead-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import supabase from "../lib/supabase";
+import { supabase } from "../lib/supabase";
 
 export default function LeadForm() {
   const [email, setEmail] = useState("");
@@ -73,7 +73,7 @@ export default function LeadForm() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="email" className="block text-sm font-bold mb-2">
-          Early Access Awaits! Sign Up for Exclusive Perks!
+           Early Access Awaits! Sign Up for Exclusive Perks!
           </label>
           <div className="relative mt-1 flex">
             <input

--- a/src/app/data/data.ts
+++ b/src/app/data/data.ts
@@ -58,7 +58,7 @@ export const feature2 = [
 export const feature3 = [
 	{
 		icon: FiList,
-		title: 'Create a whislist',
+		title: 'Create a whishlist',
 		desc: 'Checking off items from your wishilist sparks joy and fuels your motivation.',
 	},
 	{


### PR DESCRIPTION
## Typo fix on Data.ts

Just a quick fix on the Wishlist word. (it was misspelled as "Whislist")

## Solution
"Whislist" to "Wishlist"
 
Before             
:-------------------------:
![whislist](https://github.com/user-attachments/assets/03954e32-017f-4bcc-838c-ad00e2c94f29)


After
:-------------------------:
![Wishlist](https://github.com/user-attachments/assets/166a48c6-6e15-4eed-a3d2-5745a66355ea)

